### PR TITLE
fest: Add arm64 build

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -1,0 +1,40 @@
+name: docker-build-arm
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+env:
+  FOLDER: template
+  OLS_VERSION: 1.8.2
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix: 
+        PHP_VERSION: [lsphp81, lsphp82, lsphp83]
+        TAG: [latest,'']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker build and push
+        if: ${{ (github.ref == 'refs/heads/master' && github.event_name == 'push') || (github.event_name == 'workflow_dispatch') }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          cd ${{ env.FOLDER }}
+          bash build.sh --ols ${{ env.OLS_VERSION }} --php ${{ matrix.PHP_VERSION }} --tag "${{ matrix.TAG }}" --arch "aarch64" --push
+        env: 
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker build
+        if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'pull_request' }}
+        run: |
+          cd ${{ env.FOLDER }}
+          bash build.sh --ols ${{ env.OLS_VERSION }} --php ${{ matrix.PHP_VERSION }} --tag ${{ matrix.TAG }} --arch aarch64
+
+  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [<img src="https://img.shields.io/badge/slack-LiteSpeed-blue.svg?logo=slack">](litespeedtech.com/slack) 
 [<img src="https://img.shields.io/twitter/follow/litespeedtech.svg?label=Follow&style=social">](https://twitter.com/litespeedtech)
 
-Install a lightweight OpenLiteSpeed container using either the Edge or Stable version in Ubuntu 22.04 Linux.
+Install a lightweight OpenLiteSpeed container using either the Edge or Stable version in Ubuntu 24.04 Linux.
 
 ### Prerequisites
 *  [Install Docker](https://www.docker.com/)

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -2,13 +2,14 @@ FROM ubuntu:24.04
 
 ARG OLS_VERSION
 ARG PHP_VERSION
+ARG ARCH
 
 
 RUN apt-get update && apt-get install wget curl cron tzdata -y
 
-RUN wget https://openlitespeed.org/packages/openlitespeed-$OLS_VERSION.tgz && \
-    tar xzf openlitespeed-$OLS_VERSION.tgz && cd openlitespeed && ./install.sh && \
-    echo 'cloud-docker' > /usr/local/lsws/PLAT && rm -rf /openlitespeed && rm /openlitespeed-$OLS_VERSION.tgz
+RUN wget https://openlitespeed.org/packages/openlitespeed-$OLS_VERSION-$ARCH-linux.tgz && \
+    tar xzf openlitespeed-$OLS_VERSION-$ARCH-linux.tgz && cd openlitespeed && ./install.sh && \
+    echo 'cloud-docker' > /usr/local/lsws/PLAT && rm -rf /openlitespeed && rm /openlitespeed-$OLS_VERSION-$ARCH-linux.tgz
 
 RUN wget -O - https://repo.litespeed.sh | bash
 

--- a/template/build.sh
+++ b/template/build.sh
@@ -4,6 +4,7 @@ PHP_VERSION=''
 PUSH=''
 CONFIG=''
 TAG=''
+ARCH=''
 BUILDER='litespeedtech'
 REPO='openlitespeed'
 EPACE='        '
@@ -20,6 +21,8 @@ help_message(){
     echo "${EPACE}${EPACE}Example: bash build.sh --ols 1.8.2 --php lsphp83"
     echow '--push'
     echo "${EPACE}${EPACE}Example: build.sh --ols 1.8.2 --php lsphp83 --push, will push to the dockerhub"
+    echow '--arch [ARCH] (aarch64, x86_64)'
+    echo "${EPACE}${EPACE}Example: build.sh --ols 1.8.2 --php lsphp83 --arch aarch64, will build for ARM"
     exit 0
 }
 
@@ -34,7 +37,7 @@ build_image(){
         help_message
     else
         echo "${1} ${2}"
-        docker build . --tag ${BUILDER}/${REPO}:${1}-${2} --build-arg OLS_VERSION=${1} --build-arg PHP_VERSION=${2}
+        docker build . --tag ${BUILDER}/${REPO}:${1}-${2} --build-arg OLS_VERSION=${1} --build-arg PHP_VERSION=${2} --build-arg ARCH=${ARCH}
     fi    
 }
 
@@ -94,7 +97,11 @@ while [ ! -z "${1}" ]; do
             ;;
         -[tT] | -tag | -TAG | --tag) shift
             TAG="${1}"
-            ;;       
+            ;;
+        -[aA] | -arch | --arch) shift
+            check_input "${1}"
+            ARCH="${1}"
+            ;;
         --push ) shift
             PUSH=true
             ;;            


### PR DESCRIPTION
We can do ARM64 build now:

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/